### PR TITLE
Update links to exchange rate diff calculators

### DIFF
--- a/docs/infakt_routine.md
+++ b/docs/infakt_routine.md
@@ -252,8 +252,8 @@ infakt. Также, убедитесь что все ваши фактуры у�
 [17]: images/infakt_routine/zus_import_kedu_3.png
 [18]: images/infakt_routine/zus_import_kedu_4.png
 [19]: https://www.infakt.pl/blog/jak-rozliczyc-roznice-kursowe-na-ryczalcie/
-[20]: https://kalkulatory.gofin.pl/Kalkulator-roznic-kursowych-przychodow,12.html
-[21]: https://kalkulatory.gofin.pl/Kalkulator-roznic-kursowych-od-srodkow-wlasnych,12.html
+[20]: https://kalkulatory.gofin.pl/kalkulatory/kalkulator-walutowy-roznic-kursowych-przychody-w-walucie-obcej 
+[21]: https://kalkulatory.gofin.pl/kalkulatory/kalkulator-walutowy-roznic-kursowych-koszty-podatkowe-w-nbsp-walucie-obcej
 [22]: images/infakt_routine/dowod_wewnetrzny.png
 [23]: images/infakt_routine/dodatnia_ruznica.png
 [24]: https://www.infakt.pl/polecam/sobolevbel

--- a/docs/infakt_routine.md
+++ b/docs/infakt_routine.md
@@ -252,7 +252,7 @@ infakt. Также, убедитесь что все ваши фактуры у�
 [17]: images/infakt_routine/zus_import_kedu_3.png
 [18]: images/infakt_routine/zus_import_kedu_4.png
 [19]: https://www.infakt.pl/blog/jak-rozliczyc-roznice-kursowe-na-ryczalcie/
-[20]: https://kalkulatory.gofin.pl/kalkulatory/kalkulator-walutowy-roznic-kursowych-przychody-w-walucie-obcej 
+[20]: https://kalkulatory.gofin.pl/kalkulatory/kalkulator-walutowy-roznic-kursowych-przychody-w-walucie-obcej
 [21]: https://kalkulatory.gofin.pl/kalkulatory/kalkulator-walutowy-roznic-kursowych-koszty-podatkowe-w-nbsp-walucie-obcej
 [22]: images/infakt_routine/dowod_wewnetrzny.png
 [23]: images/infakt_routine/dodatnia_ruznica.png


### PR DESCRIPTION
Текущие линки ведут на 404 и затем переводят на главную страницу:
![image](https://github.com/sobolevbel/jdg/assets/42216731/88ed26fd-c102-4782-b60f-d05e76c7aba7)

Поправил ссылки на корректные ссылки для рассчёта курсовых разниц.