### PR TITLE
Docker-way build fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,13 @@ python -m mkdocs serve
 
 ### Docker-way 🙃
 
-Нужны:
+Нужен:
 - docker
-- docker-compose
 
 А дальше запускаете:
 
 ```shell
-docker-compose up --build
+docker compose up --build
 ```
 
 ### Obsidian

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   jdg:
     build: .


### PR DESCRIPTION
* Remove obsolete version parameter from docker-compose file
* Corrected README description of docker-way process

Intent is to use native `docker compose` command maintained by Docker team instead of standalone `docker-compose` package which is no longer supported