### PR TITLE
Добавлена информация об альтернативном месте поиска документа ZUS RWN

### DIFF
--- a/docs/zus.md
+++ b/docs/zus.md
@@ -264,7 +264,7 @@ ZUS состоит из 2 основных частей:
 
    ![zus_zaswiadczenie_2.7.png][14]
 
-10. Заходим в [ZUS][1]. В меню выбираем Płatnik (иногда приходит во вкладку Ogólny). Слева в меню **Dokumenty i wiadomości** **Korespondencja z ZUS**. Выбираем документ и подтверждаем получение через Profil Zaufany.
+10. Заходим в [ZUS][1]. В меню выбираем `Płatnik` (иногда приходит во вкладку `Ogólny`). Слева в меню **Dokumenty i wiadomości** **Korespondencja z ZUS**. Выбираем документ и подтверждаем получение через Profil Zaufany.
 
     ![zus_zaswiadczenie_4.png][15]
 


### PR DESCRIPTION
Сегодня как раз мой случай. Хоть внёсэк был создан из роли Płatnik, ответ ZUS RWN документа пришел во вкладку Ogólny.

Мне потребовалось достаточно времени чтобы написать письмо и дозвониться в ZUS и решить эту проблему, прежде чем файл нашелся.

В ZUS объяснить почему файл оказался во вкладке Ogólny не смогли.

Давайте сэкономим время других и укажем альтернативное место поиска документа.

Спасибо.