### PR TITLE
Fix: unnecessary insurance codes in DRA for ZUS vacation

### DIFF
--- a/docs/declarations.md
+++ b/docs/declarations.md
@@ -301,6 +301,7 @@ Cel szczególowy не всегда обязателен. Вводить его �
 - 0000396361 - [Vasilisa][49] Loban - cel szczegółowy: **0165621 Vasilisa**
 - 0000037904 - [Zlatoslava][50] Mytnik - cel szczegółowy: **40923 Mytnik Zlatoslava**
 - 0000396361 - [Artem][56] Padzialowski - cel szczegółowy: **0568766 Artyom**
+- 0000037904 - [Artur][57] Nikanau - cel szczegółowy: **44133 NIKANAU ARTUR**
 
 [Список фондов][30] от e-pity.pl.
 
@@ -402,3 +403,4 @@ podatek?".
 [54]: https://devby.io/news/support-devby24
 [55]: https://t.me/partyzanka_rb_pl/650
 [56]: https://www.siepomaga.pl/artem-padzialowski
+[57]: https://dzieciom.pl/podopieczni/44133

--- a/docs/declarations.md
+++ b/docs/declarations.md
@@ -402,4 +402,3 @@ podatek?".
 [54]: https://devby.io/news/support-devby24
 [55]: https://t.me/partyzanka_rb_pl/650
 [56]: https://www.siepomaga.pl/artem-padzialowski
-

--- a/docs/zus_vacation.md
+++ b/docs/zus_vacation.md
@@ -251,7 +251,7 @@ NIP других предпринимателей, а также размер п
 
 - **ZUS RCA 1**: именной отчет социального страхования (składka na ubezpieczenie społeczne) **с учётом каникул**. В отчете нужно указать **соответствующий Kod tytułu ubezpieczenia - 0514 для Duży ZUS, 0574 для Składki preferencyjne, 0594 для Mały ZUS Plus.**
 - **ZUS RCA 2**: именной отчет страхования здоровья (składka na ubezpieczenie zdrowotne) и при наличии включающий также добровольные больничные взносы (dobrowolne ubezpieczenie chorobowe) **без учета каникул**. В отчете нужно указать **актуальный Kod tytułu ubezpieczenia - 0510 для Duży ZUS, 0570 для Składki preferencyjne, 0590 для Mały ZUS Plus.**
-- **ZUS DRA**: декларация по взносам **с учётом каникул**. В декларации нужно указать **соответствующий Kod tytułu ubezpieczenia - 0514 для Duży ZUS, 0574 для Składki preferencyjne, 0594 для Mały ZUS Plus.**
+- **ZUS DRA**: декларация по взносам **с учётом каникул**. В декларации в разделе оплаты за категории социального страхования (разделы **Składki finansowane przez**) значения должны быть указаны в полях _budżet państwa_ вместо _ubezpieczonych_.
 
 На наемных работников не распространяется льгота ZUS-каникул.
 Предприниматель в случае наличия наемных работников должен подать за них следующие документы:


### PR DESCRIPTION
* Remove insurance codes mentions from DRA section on ZUS vacation page