### PR TITLE
Update wFirma promo codes: year code verified, Henry's referral code restored

### DIFF
--- a/docs/wfirma_settings.en.md
+++ b/docs/wfirma_settings.en.md
@@ -10,7 +10,7 @@ tags:
 
 ## wFirma online bookkeeping — first year free 🪄
 
-Subscription for sole trader bookkeeping 2026: `MALAKSIEGOWOSC-2026` (1 year) or `PROX-KSIEGOWOSC` (3 months) (works for ryczałt, skala podatkowa, liniowy).
+Subscription for sole trader bookkeeping 2026: `MALAKSIEGOWOSC-2026` (1 year) or `K9D6ECEE29` (referral code from pointless_henry, one of the chat regulars) (works for ryczałt, skala podatkowa, liniowy).
 
 Register only via this link ▶️ [https://wfirma.pl/rejestracja-przez-kody](https://wfirma.pl/rejestracja-przez-kody) ◀️
 

--- a/docs/wfirma_settings.md
+++ b/docs/wfirma_settings.md
@@ -10,7 +10,7 @@ tags:
 
 ## Онлайн бухгалтерия wFirma первый год бесплатно 🪄
 
-Подписка для бухгалтерии ИП 2026: `MALAKSIEGOWOSC-2026` (1 год) или `PROX-KSIEGOWOSC` (3 мес.) (подходит для ryczałt, skala podatkowa, liniowy).
+Подписка для бухгалтерии ИП 2026: `MALAKSIEGOWOSC-2026` (1 год) или `K9D6ECEE29` (реферальный код pointless_henry, активиста чата) (подходит для ryczałt, skala podatkowa, liniowy).
 
 Регистрироваться только по этой ссылке ▶️ [https://wfirma.pl/rejestracja-przez-kody](https://wfirma.pl/rejestracja-przez-kody) ◀️
 


### PR DESCRIPTION
## Что сделано

Строка промокодов wFirma на странице настройки (RU + EN) теперь содержит два кода:

- `MALAKSIEGOWOSC-2026` (1 год) — проверен: официально опубликован на [wfirma.pl/ksiegowosc-dla-kazdego](https://wfirma.pl/ksiegowosc-dla-kazdego) («Podaj kod MALAKSIEGOWOSC-2026 i zyskaj rok korzystania za darmo»).
- `K9D6ECEE29` — реферальный код pointless_henry (активиста чата). Был добавлен в #254, удалён в df7deba при ревизии контента как неопознанный; возвращён с подписью, чтобы не выпал при следующей чистке.

Код `PROX-KSIEGOWOSC` (3 мес.) убран.