### PR TITLE
Fix dead links and silence link-checker false positives

### DIFF
--- a/docs/workflow.en.md
+++ b/docs/workflow.en.md
@@ -116,9 +116,9 @@ List of documents:
 [5]: infakt_routine.md#receiving-payment-and-accounting-for-exchange-rate-differences
 [6]: https://pomoc.ifirma.pl/pomoc-artykul/transakcyjne-roznice-kursowe-u-ryczaltowca
 [7]: https://www.ifirma.pl/blog/roznice-kursowe-od-srodkow-wlasnych-a-ryczalt.html
-[8]: https://www.nbp.pl/home.aspx?c=/ascx/archa.ascx
+[8]: https://nbp.pl/en/statistic-and-financial-reporting/rates/archive-table-a-csv-xls/
 [9]: https://www.podatki.gov.pl/vat/e-deklaracje-vat/formularze-vat/#VAT-UE
-[10]: https://www.podatki.gov.pl/e-deklaracje/wtyczka-do-podpisywania-i-przesylania-danych-xml-z-interaktywnych-formularzy-pdf/
+[10]: https://podatki-arch.mf.gov.pl/e-deklaracje/wtyczka-do-podpisywania-i-przesylania-danych-xml-z-interaktywnych-formularzy-pdf/
 [11]: https://stat.gov.pl/metainformacje/slownik-pojec/pojecia-stosowane-w-statystyce-publicznej/938,pojecie.html
 [12]: https://poradnikprzedsiebiorcy.pl/-ewidencja-srodkow-trwalych
 [13]: https://sobolevbel.github.io/jdg/zus_vacation/#ezhemesiachnye-otchioty-vo-vremia-zus-kanikul

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -117,9 +117,9 @@ tags:
 [6]: infakt_routine.md#poluchenie-oplaty-i-uchet-kursovykh-raznits
 [7]: https://pomoc.ifirma.pl/pomoc-artykul/transakcyjne-roznice-kursowe-u-ryczaltowca
 [8]: https://www.ifirma.pl/blog/roznice-kursowe-od-srodkow-wlasnych-a-ryczalt.html
-[9]: https://www.nbp.pl/home.aspx?c=/ascx/archa.ascx
+[9]: https://nbp.pl/statystyka-i-sprawozdawczosc/kursy/archiwum-tabela-a-csv-xls/
 [10]: https://www.podatki.gov.pl/vat/e-deklaracje-vat/formularze-vat/#VAT-UE
-[11]: https://www.podatki.gov.pl/e-deklaracje/wtyczka-do-podpisywania-i-przesylania-danych-xml-z-interaktywnych-formularzy-pdf/
+[11]: https://podatki-arch.mf.gov.pl/e-deklaracje/wtyczka-do-podpisywania-i-przesylania-danych-xml-z-interaktywnych-formularzy-pdf/
 [12]: https://stat.gov.pl/metainformacje/slownik-pojec/pojecia-stosowane-w-statystyce-publicznej/938,pojecie.html
 [13]: https://poradnikprzedsiebiorcy.pl/-ewidencja-srodkow-trwalych
 [14]: https://sobolevbel.github.io/jdg/zus_vacation/#ezhemesiachnye-otchioty-vo-vremia-zus-kanikul

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -4,15 +4,19 @@
       "urls": [
         "https://docs.github.com/",
         "https://aplikacja.ceidg.gov.pl/",
-        "https://www.podatki.gov.pl/"
+        "https://www.podatki.gov.pl/",
+        "https://podatki-arch.mf.gov.pl/"
       ],
       "headers": {
         "Accept-Encoding": "zstd, br, gzip, deflate"
       }
     }
   ],
-  "aliveStatusCodes": [200, 204],
+  "aliveStatusCodes": [200, 202, 204],
   "ignorePatterns": [
+    {
+      "pattern": "^#"
+    },
     {
       "pattern": "^https://.*\\.infakt\\.pl"
     },
@@ -30,6 +34,18 @@
     },
     {
       "pattern": "^https://buymeacoffee.com"
+    },
+    {
+      "pattern": "^https://(www\\.)?nbp\\.pl"
+    },
+    {
+      "pattern": "^https://eskladka\\.pl"
+    },
+    {
+      "pattern": "^https://mos\\.cudzoziemcy\\.gov\\.pl"
+    },
+    {
+      "pattern": "^https://ursynow\\.um\\.warszawa\\.pl"
     }
   ]
 }


### PR DESCRIPTION
CI по ссылкам падал на PR #300. Разбор всех срабатываний:

## Реально битые ссылки (заменены)

- **NBP, архив курсов** (workflow RU+EN): старый `www.nbp.pl/home.aspx?c=/ascx/archa.ascx` умер вместе со старым порталом → заменён на новые адреса [nbp.pl/statystyka-i-sprawozdawczosc/kursy/archiwum-tabela-a-csv-xls](https://nbp.pl/statystyka-i-sprawozdawczosc/kursy/archiwum-tabela-a-csv-xls/) (RU) и [/en/-вариант](https://nbp.pl/en/statistic-and-financial-reporting/rates/archive-table-a-csv-xls/) (EN), оба проверены — 200.
- **Плагин e-Deklaracje** (workflow RU+EN): страница на podatki.gov.pl отдаёт настоящий 404 → указана официальная архивная копия [podatki-arch.mf.gov.pl](https://podatki-arch.mf.gov.pl/e-deklaracje/wtyczka-do-podpisywania-i-przesylania-danych-xml-z-interaktywnych-formularzy-pdf/) (200).

## Ложные срабатывания (правки mlc_config.json)

- **Все внутристраничные якоря** (`#pit-28-cherez-twoj-e-pit` и т.п.): чекер строит слаги по-гитхабовски (кириллица остаётся кириллицей), а mkdocs транслитерирует. Все флагнутые якоря проверены по собранному `site/` — существуют. Добавлен ignorePattern `^#`.
- **mojafirma.org** (202): Cloudflare отвечает ботам 202 Accepted; в браузере обе страницы живы. 202 добавлен в aliveStatusCodes.
- **nbp.pl** (403): новый портал за Imperva-антиботом («Pardon Our Interruption»), CI всегда будет получать 403 → домен в ignorePatterns (ссылки при этом обновлены и живы).
- **eskladka.pl, mos.cudzoziemcy.gov.pl** (status 0): рвут соединение с CI-раннеров, в браузере живы → ignorePatterns.
- **ursynow.um.warszawa.pl** (403): антибот, страница жива → ignorePatterns.
- podatki-arch.mf.gov.pl добавлен в httpHeaders с Accept-Encoding-обходом, как остальные домены Минфина.