### PR TITLE
Remove the K9D6ECEE29 code: it is not Henry's referral code

### DIFF
--- a/docs/wfirma_settings.en.md
+++ b/docs/wfirma_settings.en.md
@@ -10,7 +10,7 @@ tags:
 
 ## wFirma online bookkeeping — first year free 🪄
 
-Subscription for sole trader bookkeeping 2026: `MALAKSIEGOWOSC-2026` (1 year) or `K9D6ECEE29` (referral code from pointless_henry, one of the chat regulars) (works for ryczałt, skala podatkowa, liniowy).
+Subscription for sole trader bookkeeping 2026: `MALAKSIEGOWOSC-2026` (1 year) (works for ryczałt, skala podatkowa, liniowy).
 
 Register only via this link ▶️ [https://wfirma.pl/rejestracja-przez-kody](https://wfirma.pl/rejestracja-przez-kody) ◀️
 

--- a/docs/wfirma_settings.md
+++ b/docs/wfirma_settings.md
@@ -10,7 +10,7 @@ tags:
 
 ## Онлайн бухгалтерия wFirma первый год бесплатно 🪄
 
-Подписка для бухгалтерии ИП 2026: `MALAKSIEGOWOSC-2026` (1 год) или `K9D6ECEE29` (реферальный код pointless_henry, активиста чата) (подходит для ryczałt, skala podatkowa, liniowy).
+Подписка для бухгалтерии ИП 2026: `MALAKSIEGOWOSC-2026` (1 год) (подходит для ryczałt, skala podatkowa, liniowy).
 
 Регистрироваться только по этой ссылке ▶️ [https://wfirma.pl/rejestracja-przez-kody](https://wfirma.pl/rejestracja-przez-kody) ◀️
 


### PR DESCRIPTION
Код `K9D6ECEE29` удалён со страницы настройки wFirma (RU + EN) — атрибуция из #300 оказалась неверной, это не реферальный код pointless_henry. Остался только проверенный код на бесплатный год `MALAKSIEGOWOSC-2026`.